### PR TITLE
Fix prpList regeneration in dma

### DIFF
--- a/hil/nvme/dma.cc
+++ b/hil/nvme/dma.cc
@@ -156,6 +156,13 @@ void PRPList::getPRPListFromPRP(uint64_t base, uint64_t size) {
       // PRP list ends but size is not full
       // Last item of PRP list is pointer of another PRP
       // list
+
+      /* We must also account for currentSize variable.
+       * In case the last entry in the list is a pointer to another list
+       * currentSize must be decremented back by 8
+       */
+      currentSize -= listPRPSize;
+
       listPRP = pThis->prpList.back().addr;
       pThis->prpList.pop_back();
 


### PR DESCRIPTION
In case the write request requires multiple prpLists, the list entries will be incorrectly retrieved from the prpList block because the size is not properly accounted for. If the last entry of the prpList is a pointer to another list we must decrement the currentSize variable.

To reproduce the bug you can:
Enable disk image.
Populate PRP region with data.
Attempt to write more than 4104 Logical Blocks (LBA size 512) to a 512 aligned SLBA.
View the contents of the disk image. If size = 4105 LBA then the last 512 B of the PRP region will not be written to the disk image.
